### PR TITLE
Update/exposuretime json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+MOVE TO GITHUB RELEASE https://github.com/Sensing-Dev/viewer/releases, no longer update here
+
 ### Update 2024-09-13:
 1. fix and enabled delete checkbox
 2. add delete option to json file

--- a/convert.py
+++ b/convert.py
@@ -1,6 +1,7 @@
 import json
 import shutil
 import time
+import traceback
 
 import cv2
 import numpy as np
@@ -74,7 +75,7 @@ class Converter:
                             del_bin(file_path, time_out)
                     log_write("DEBUG", "Device {}: Finish saving images in {}".format(i, output_directory))
                 except Exception as e:
-                    log_write("Error", e)
+                    log_write("Error", traceback.format_exc())
 
         prefix_name0 = DEFAULT_GENDC_PREFIX_NAME0 if is_gendc else DEFAULT_PREFIX_NAME0
         prefix_name1 = DEFAULT_GENDC_PREFIX_NAME1 if is_gendc else DEFAULT_PREFIX_NAME1
@@ -318,7 +319,7 @@ class Converter:
                 log_write("DEBUG", "Device {}: Finish saving video in {}".format(i, output_directory))
 
             except Exception as e:
-                log_write("Error", e)
+                log_write("WARNING", traceback.format_exc())
             finally:
                 for writer in video_writers:
                     writer.release()
@@ -474,7 +475,7 @@ def read_config(file_path, time_out):
                 sensor_info = json.load(f)
             succeed = True
         except:
-            pass
+            log_write("WARNING", traceback.format_exc())
     if len(sensor_info) == 0:
         log_write("WARNING", "config file is empty")
 

--- a/gui.py
+++ b/gui.py
@@ -57,7 +57,9 @@ class U3VCameraGUI:
 
         self.num_device = dev_info["Number of Devices"]
         self.pixel_format = dev_info["PixelFormat"]
+
         self.fps = dev_info["FrameRate"]
+        self.exposuretime_max = dev_info["ExposureTime Max"]
 
         default_directory = test_info["Default Directory"]
         winfos = test_info["Window infos"]
@@ -398,7 +400,10 @@ class U3VCameraGUI:
                 "b_gains": self.display.b_gains,
                 "gendc_mode": self.is_gendc_mode,
                 "delete_bin": self.delete_bin.get(),
-                "winfos": winfos
+                "winfos": winfos,
+####################        ADDITIONAL INFORMATION         ###########################
+                "exposuretime max":  self.exposuretime_max,
+                "fps": self.fps
             }
 
 

--- a/gui.py
+++ b/gui.py
@@ -403,13 +403,14 @@ class U3VCameraGUI:
                 "winfos": winfos,
 ####################        ADDITIONAL INFORMATION         ###########################
                 "exposuretime max":  self.exposuretime_max,
-                "fps": self.fps
+                "fps": self.fps,
+                "pixelformat": self.pixel_format
             }
 
 
             for i in range(self.num_device):
                 with open('default.json', 'w') as f:
-                    json.dump(config, f)
+                    json.dump(config, f, indent=4, separators=(',', ': '))
 
         log_write("DEBUG", "Closing...")
 

--- a/utils.py
+++ b/utils.py
@@ -158,7 +158,7 @@ def get_device_info(parser, load_json_path="default.json"):
                           f"While OperationMode is set to {dev_info['OperationMode']}, Number of Devices is set to {dev_info['Number of Devices']} (Default: 1)")
                 dev_info["Number of Devices"] = expected_num_device
 
-        if load_json and dev_info["Number of Devices"] != setting_config["device number"]:
+        if load_json and "device number" in setting_config and dev_info["Number of Devices"] != setting_config["device number"]:
             load_json = False
 
         if dev_info["Number of Devices"] == 2:
@@ -220,7 +220,7 @@ def get_device_info(parser, load_json_path="default.json"):
                 dev_info["ExposureTime Max"] = setting_config["exposuretime max"]
             else:
                 log_write("ERROR", "Please manually set maximum exposure time in json file")
-                return
+                raise Exception()
 
         dev_info["PayloadSize"] = []
         for i in range(dev_info["Number of Devices"]):
@@ -230,9 +230,12 @@ def get_device_info(parser, load_json_path="default.json"):
         dev_info[dev_info["ExposureTime Key"]] = []
 
         if load_json:
-            dev_info[dev_info["Gain Key"]] = [min(gain, dev_info["Gain Max"]) for gain in setting_config["gains"]]
-            dev_info[dev_info["ExposureTime Key"]] = [min(exp, dev_info["ExposureTime Max"]) for exp in setting_config["exposuretimes"]]
+            dev_info[dev_info["Gain Key"]] = [min(gain, dev_info["Gain Max"]) for gain in setting_config["gains"]] \
+                                          if load_json and "gains" in setting_config else [dev_info["Gain Max"]] * dev_info["Number of Devices"]
 
+            dev_info[dev_info["ExposureTime Key"]] = [min(exp, dev_info["ExposureTime Max"]) for exp in setting_config["exposuretimes"]] \
+                                                 if load_json and "exposuretimes" in setting_config else \
+                                                [dev_info["ExposureTime Max"]] * dev_info["Number of Devices"]
         else:
             for i in range(dev_info["Number of Devices"]):
                 try:

--- a/utils.py
+++ b/utils.py
@@ -99,8 +99,8 @@ def get_device_info(parser, load_json_path="default.json"):
             dev_info["FrameRate"] = 25
 
         dev_info["ExposureTime Min"] = 0.0
-        if "exposuretime max" in setting_config:
-            dev_info["ExposureTime Max"] = setting_config["exposuretime max"]
+        if "exposuretime_max" in setting_config:
+            dev_info["ExposureTime Max"] = setting_config["exposuretime_max"]
         else:
             dev_info["ExposureTime Max"] = 1.0 / dev_info["FrameRate"] * 1000 * 1000
 
@@ -171,7 +171,16 @@ def get_device_info(parser, load_json_path="default.json"):
 
         dev_info["Width"] = devices[0].get_integer_feature_value("Width")
         dev_info["Height"] = devices[0].get_integer_feature_value("Height")
-        dev_info["PixelFormat"] = devices[0].get_string_feature_value("PixelFormat")
+
+        # If there is a conflict, please remove the pixelformat entry from default.json
+        if "pixelformat" in setting_config:
+            dev_info["PixelFormat"] = setting_config["pixelformat"]
+        else:
+            try:
+                dev_info["PixelFormat"] = devices[0].get_string_feature_value("PixelFormat")
+            except:
+                log_write("ERROR", "Can not found pixelformat from config, please manually set PixelFormat in json file")
+                raise Exception()
 
         if dev_info["PixelFormat"] not in pfnc:
             log_write("ERROR", "{} is currently not supported on calibration tool".format(dev_info["PixelFormat"]))
@@ -200,7 +209,7 @@ def get_device_info(parser, load_json_path="default.json"):
             dev_info["Gain Min"] = float(devices[0].get_integer_feature_bounds(dev_info["Gain Key"])[0])
             dev_info["Gain Max"] = float(devices[0].get_integer_feature_bounds(dev_info["Gain Key"])[1])
 
-        has_framerate_feature = False
+        has_fps_feature = False
         # get frame rate by AcquisitionFrameRate
         try:
             dev_info["FrameRate"] = devices[0].get_float_feature_value("AcquisitionFrameRate")
@@ -210,16 +219,17 @@ def get_device_info(parser, load_json_path="default.json"):
             if "fps" in setting_config:
                 dev_info["FrameRate"] = setting_config["fps"]
             else:
-                dev_info["FrameRate"] = 30  # use default fps = 30
+                log_write("ERROR", "Can not found fps from config, please manually set FrameRate in json file")
+                raise Exception()
 
         dev_info["ExposureTime Min"] = 0.0
-        if has_framerate_feature:
+        if has_fps_feature:
             dev_info["ExposureTime Max"] = 1.0 / dev_info["FrameRate"] * 1000 * 1000
         else:
-            if "exposuretime max" in setting_config:
-                dev_info["ExposureTime Max"] = setting_config["exposuretime max"]
+            if "exposuretime_max" in setting_config:
+                dev_info["ExposureTime Max"] = setting_config["exposuretime_max"]
             else:
-                log_write("ERROR", "Please manually set maximum exposure time in json file")
+                log_write("ERROR", "Can not found exposuretime max from config, please manually set maximum exposure time in json file")
                 raise Exception()
 
         dev_info["PayloadSize"] = []

--- a/utils.py
+++ b/utils.py
@@ -32,14 +32,6 @@ pfnc = {
     "BayerRG12": {"value": 0x01100013, "depth": 12, "dim": 2},
 }
 
-
-def switchFontColor(color_mode, current_color=None):
-    if color_mode:
-        return (255, 255, 255) if current_color == (0, 0, 0) else (0, 0, 0)
-    else:
-        return (65535, 65535, 65535) if current_color == (0, 0, 0) else (0, 0, 0)
-
-
 def set_commandline_options():
     parser = argparse.ArgumentParser(description="U3V Camera")
     parser.add_argument('-d', '--directory', default='./output', type=str, help='Directory to save log')
@@ -67,14 +59,14 @@ def log_write(logtype, msg):
 
 # get device info ##############################################################
 def get_device_info(parser, load_json_path="default.json"):
+    dev_info = {}
+    test_info = {}
+    setting_config = {}
     load_json = False
     if os.path.isfile(load_json_path):
         with open(load_json_path, 'r') as f:
             setting_config = json.load(f)
         load_json = True
-
-    dev_info = {}
-    test_info = {}
 
     # get user input
     args = parser.parse_args()
@@ -87,7 +79,7 @@ def get_device_info(parser, load_json_path="default.json"):
         if not os.path.isdir(test_info["Default Directory"]):
             os.mkdir(test_info["Default Directory"])
         dev_info["Number of Devices"] = 2
-        if load_json and dev_info["Number of Devices"] != setting_config["device number"]:
+        if load_json and "device number" in setting_config and dev_info["Number of Devices"] != setting_config["device number"]:
             load_json = False
         dev_info["Width"] = 640
         dev_info["Height"] = 480
@@ -95,16 +87,27 @@ def get_device_info(parser, load_json_path="default.json"):
         dev_info["PixelFormat"] = args.pixel_format
         dev_info["PayloadSize"] = [dev_info["Width"] * dev_info["Height"] * required_bit_depth(
             dev_info["PixelFormat"]) // 8] * dev_info["Number of Devices"]
-        dev_info["FrameRate"] = 25
         dev_info["Gain Min"] = 0
         dev_info["Gain Max"] = 100
         dev_info["Gain Key"] = "Gain"
-        dev_info[dev_info["Gain Key"]] = setting_config["gains"] if load_json else [40] * dev_info["Number of Devices"]
-        dev_info["ExposureTime Min"] = 1
-        dev_info["ExposureTime Max"] = 1.0 / dev_info["FrameRate"] * 1000 * 1000
+        dev_info[dev_info["Gain Key"]] = [min(gain, dev_info["Gain Max"]) for gain in setting_config["gains"]] \
+                                          if load_json and "gains" in setting_config else [dev_info["Gain Max"]] * dev_info["Number of Devices"]
+
+        if "fps" in setting_config:
+            dev_info["FrameRate"] = setting_config["fps"]
+        else:
+            dev_info["FrameRate"] = 25
+
+        dev_info["ExposureTime Min"] = 0.0
+        if "exposuretime max" in setting_config:
+            dev_info["ExposureTime Max"] = setting_config["exposuretime max"]
+        else:
+            dev_info["ExposureTime Max"] = 1.0 / dev_info["FrameRate"] * 1000 * 1000
+
         dev_info["ExposureTime Key"] = "ExposureTimeAbs"
-        dev_info[dev_info["ExposureTime Key"]] = setting_config["exposuretimes"] if load_json else [100] * dev_info[
-            "Number of Devices"]
+        dev_info[dev_info["ExposureTime Key"]] = [min(exp, dev_info["ExposureTime Max"]) for exp in setting_config["exposuretimes"]] \
+                                                 if load_json and "exposuretimes" in setting_config else \
+                                                [dev_info["ExposureTime Max"]] * dev_info["Number of Devices"]
 
         if dev_info["PixelFormat"].startswith("Bayer"):
             test_info["Color Display Mode"] = True
@@ -169,10 +172,7 @@ def get_device_info(parser, load_json_path="default.json"):
         dev_info["Width"] = devices[0].get_integer_feature_value("Width")
         dev_info["Height"] = devices[0].get_integer_feature_value("Height")
         dev_info["PixelFormat"] = devices[0].get_string_feature_value("PixelFormat")
-        try:
-            dev_info["FrameRate"] = devices[0].get_float_feature_value("AcquisitionFrameRate")
-        except:
-            dev_info["FrameRate"] = 30  # how to get the framerate for kizashi 1.0?
+
         if dev_info["PixelFormat"] not in pfnc:
             log_write("ERROR", "{} is currently not supported on calibration tool".format(dev_info["PixelFormat"]))
             del devices[0]
@@ -196,16 +196,31 @@ def get_device_info(parser, load_json_path="default.json"):
         try:
             dev_info["Gain Min"] = devices[0].get_float_feature_bounds(dev_info["Gain Key"])[0]
             dev_info["Gain Max"] = devices[0].get_float_feature_bounds(dev_info["Gain Key"])[1]
-            # calculated
-            dev_info["ExposureTime Min"] = 1.0
-            dev_info["ExposureTime Max"] = 1.0 / dev_info["FrameRate"] * 1000 * 1000
-
         except:
             dev_info["Gain Min"] = float(devices[0].get_integer_feature_bounds(dev_info["Gain Key"])[0])
             dev_info["Gain Max"] = float(devices[0].get_integer_feature_bounds(dev_info["Gain Key"])[1])
-            # calculated
-            dev_info["ExposureTime Min"] = 1.0
+
+        has_framerate_feature = False
+        # get frame rate by AcquisitionFrameRate
+        try:
+            dev_info["FrameRate"] = devices[0].get_float_feature_value("AcquisitionFrameRate")
+            has_framerate_feature = True
+        except:
+            # if not, set by json file
+            if "fps" in setting_config:
+                dev_info["FrameRate"] = setting_config["fps"]
+            else:
+                dev_info["FrameRate"] = 30  # use default fps = 30
+
+        dev_info["ExposureTime Min"] = 0.0
+        if has_framerate_feature:
             dev_info["ExposureTime Max"] = 1.0 / dev_info["FrameRate"] * 1000 * 1000
+        else:
+            if "exposuretime max" in setting_config:
+                dev_info["ExposureTime Max"] = setting_config["exposuretime max"]
+            else:
+                log_write("ERROR", "Please manually set maximum exposure time in json file")
+                return
 
         dev_info["PayloadSize"] = []
         for i in range(dev_info["Number of Devices"]):
@@ -215,8 +230,8 @@ def get_device_info(parser, load_json_path="default.json"):
         dev_info[dev_info["ExposureTime Key"]] = []
 
         if load_json:
-            dev_info[dev_info["Gain Key"]] = setting_config["gains"]
-            dev_info[dev_info["ExposureTime Key"]] = setting_config["exposuretimes"]
+            dev_info[dev_info["Gain Key"]] = [min(gain, dev_info["Gain Max"]) for gain in setting_config["gains"]]
+            dev_info[dev_info["ExposureTime Key"]] = [min(exp, dev_info["ExposureTime Max"]) for exp in setting_config["exposuretimes"]]
 
         else:
             for i in range(dev_info["Number of Devices"]):
@@ -236,12 +251,12 @@ def get_device_info(parser, load_json_path="default.json"):
         Aravis.shutdown()
 
     test_info["acquisition-bb"] = get_bb_for_obtain_image(dev_info["Number of Devices"], dev_info["PixelFormat"])
-    test_info["Red Gains"] = setting_config["r_gains"] if load_json else [1.0] * dev_info["Number of Devices"]
-    test_info["Blue Gains"] = setting_config["g_gains"] if load_json else [1.0] * dev_info["Number of Devices"]
-    test_info["Green Gains"] = setting_config["b_gains"] if load_json else [1.0] * dev_info["Number of Devices"]
-    test_info["Gendc Mode"] = setting_config["gendc_mode"] if load_json and dev_info["GenDCStreamingMode"] else False
-    test_info["Delete Bins"] = setting_config["delete_bin"] if load_json else True
-    test_info["Window infos"] = setting_config["winfos"] if load_json else [dev_info['Width'], dev_info['Height']] * \
+    test_info["Red Gains"] = setting_config["r_gains"] if load_json and "r_gains" in setting_config else [1.0] * dev_info["Number of Devices"]
+    test_info["Blue Gains"] = setting_config["g_gains"] if load_json and "g_gains" in setting_config else [1.0] * dev_info["Number of Devices"]
+    test_info["Green Gains"] = setting_config["b_gains"] if load_json and "b_gains" in setting_config else [1.0] * dev_info["Number of Devices"]
+    test_info["Gendc Mode"] = setting_config["gendc_mode"] if load_json and dev_info["GenDCStreamingMode"] and "gendc_mode" in setting_config else False
+    test_info["Delete Bins"] = setting_config["delete_bin"] if load_json and "delete_bin" in setting_config else True
+    test_info["Window infos"] = setting_config["winfos"] if load_json and "winfos" in setting_config else [dev_info['Width'], dev_info['Height']] * \
                                                                            dev_info["Number of Devices"]
 
     for key in dev_info:

--- a/utils.py
+++ b/utils.py
@@ -84,7 +84,11 @@ def get_device_info(parser, load_json_path="default.json"):
         dev_info["Width"] = 640
         dev_info["Height"] = 480
 
-        dev_info["PixelFormat"] = args.pixel_format
+        if "pixelformat" in setting_config:
+            dev_info["PixelFormat"] = setting_config["pixelformat"]
+        else:
+            dev_info["PixelFormat"] = args.pixel_format
+
         dev_info["PayloadSize"] = [dev_info["Width"] * dev_info["Height"] * required_bit_depth(
             dev_info["PixelFormat"]) // 8] * dev_info["Number of Devices"]
         dev_info["Gain Min"] = 0
@@ -99,8 +103,8 @@ def get_device_info(parser, load_json_path="default.json"):
             dev_info["FrameRate"] = 25
 
         dev_info["ExposureTime Min"] = 0.0
-        if "exposuretime_max" in setting_config:
-            dev_info["ExposureTime Max"] = setting_config["exposuretime_max"]
+        if "exposuretime max" in setting_config:
+            dev_info["ExposureTime Max"] = setting_config["exposuretime max"]
         else:
             dev_info["ExposureTime Max"] = 1.0 / dev_info["FrameRate"] * 1000 * 1000
 
@@ -222,8 +226,8 @@ def get_device_info(parser, load_json_path="default.json"):
                 raise e
 
         dev_info["ExposureTime Min"] = 0.0
-        if "exposuretime_max" in setting_config:
-            dev_info["ExposureTime Max"] = setting_config["exposuretime_max"]
+        if "exposuretime max" in setting_config:
+            dev_info["ExposureTime Max"] = setting_config["exposuretime max"]
         elif has_fps_feature:
             dev_info["ExposureTime Max"] = 1.0 / dev_info["FrameRate"] * 1000 * 1000
         else:


### PR DESCRIPTION
Adding a new feature on default.json to set ExposureTime max, frame rate , pixel format manually 

## usage 
if "pixelformat " "exposuretime max" and "fps" are  specified in json file, they will overwrite the value retrieved by api call `get_float_feature_value("xxxxx")`. so If there is a conflict, please remove the entry from default.json
1. create a new default.json
add
`{ "exposuretime max": 16666.660308840314, "fps": 60.000022888183594, "pixelformat": "Mono12"}` to file

2. after run python gui.py and reopen the default.json
```
{
    "device number": 2,
    "gains": [
        40,
        40
    ],
    "exposuretimes": [
        100,
        100
    ],
    "r_gains": [
        1.0,
        1.0
    ],
    "g_gains": [
        1.0,
        1.0
    ],
    "b_gains": [
        1.0,
        1.0
    ],
    "gendc_mode": false,
    "delete_bin": true,
    "winfos": [
        417,
        288,
        640,
        480
    ],
    "exposuretime max": 40000.0,
    "fps": 25,
    "pixelformat": "BayerBG8"
}
```